### PR TITLE
Fixes issue with links having to be declared in stopwords with the trail...

### DIFF
--- a/lib/Pod/Wordlist.pm
+++ b/lib/Pod/Wordlist.pm
@@ -117,15 +117,15 @@ sub _strip_a_word {
 	my ($self, $word) = @_;
 	my $remainder;
 
+	# try word as-is, including possible hyphenation vs stoplist
+	if ($self->is_stopword($word) ) {
+		$remainder = '';
+	}
 	# internal period could be abbreviations, so check with
 	# trailing period restored and drop or keep on that basis
-	if ( /\./ ) {
+	elsif ( /\./ ) {
 		my $abbr = "$word.";
-		$remainder = $self->is_stopword($abbr) ? '' : $abbr;
-	}
-	# try word as-is, including possible hyphenation vs stoplist
-	elsif ($self->is_stopword($word) ) {
-		$remainder = '';
+		$remainder = $self->is_stopword($abbr) ? '' : $word;
 	}
 	# check individual parts of hyphenated word, keep whatever isn't a
 	# stopword as individual words


### PR DESCRIPTION
## ...ing period at the end

Basically, the issue is that if I have links, say, `L<foo.com|http://bar.org>`, the original code tries to check `foo.com.` (note period at the end) as the stop word; fails, and changes the word to `foo.com.`

This is especially confusing when running things like `Test::Spelling` the output of which produces

```
# Errors:
#     com
#     doingitwrong
#     www
```

Even though `www.doingitwrong.com` AND `com doingitwrong www` are in the stopwords inside the POD with `=for stopwords`

What the fix basically does is first check for whether the word is a stop word, then try and see whether it's got a dot in it, and if it does and the +dot version isn't a stop word, then leave the word as it were (i.e. do not set `$remainder` to $word+dot.

Dunno if that's the general idea of how that bit of code is meant to work, but I know that this merge fixes my link issue and doesn't add dots at the ends of words when I didn't want any :)
