### PR TITLE
- Fixed the warning thrown by method strip_stopwords().

### DIFF
--- a/lib/Pod/Wordlist.pm
+++ b/lib/Pod/Wordlist.pm
@@ -132,7 +132,7 @@ sub strip_stopwords {
 		print "  Keeping as  <$_>\n" if $_ && $self->_is_debug;
 	}
 
-	return join(" ", grep { length } @words );
+	return join(" ", grep { defined && length } @words );
 }
 
 sub _strip_a_word {


### PR DESCRIPTION
Hi, please review the above change.

While installing package Net::OpenSSH, I came across the following warning during the test stage. This PR tries to resolve the warning.

t/pod-spell.t .. Use of uninitialized value $_ in length at /usr/local/share/perl/5.10.1/Pod/Wordlist.pm line 112, <$in_fh> line 2935.
t/pod-spell.t .. 1/15 Use of uninitialized value $_ in length at /usr/local/share/perl/5.10.1/Pod/Wordlist.pm line 112, <$in_fh> line 148.

Best Regards,
Mohammad S Anwar