### PR TITLE
Replace File::ShareDir::ProjectDistDir with explicit code.

### DIFF
--- a/lib/Pod/Wordlist.pm
+++ b/lib/Pod/Wordlist.pm
@@ -2,8 +2,6 @@ package Pod::Wordlist;
 use strict;
 use warnings;
 use Lingua::EN::Inflect 'PL';
-use File::ShareDir::ProjectDistDir 1.000
-	dist_file => defaults => { pathtiny => 1 , strict => 1 };
 
 use Class::Tiny {
     wordlist  => \&_copy_wordlist,
@@ -11,7 +9,20 @@ use Class::Tiny {
     no_wide_chars => 0,
 };
 
+use Path::Tiny qw( path );
 use constant MAXWORDLENGTH => 50; ## no critic ( ProhibitConstantPragma )
+use constant _DIST_DIR => do {
+  my $dir;
+  if ( -e __FILE__ ) {
+    my $local_dir = path(__FILE__)->parent->parent->parent->child('share/dist/Pod-Spell');
+    $dir = $local_dir->absolute if -e $local_dir;
+  }
+  if ( not defined $dir ) {
+    require File::ShareDir;
+    $dir = File::ShareDir::dist_dir('Pod-Spell');
+  }
+  "$dir";
+};
 
 # VERSION
 
@@ -19,7 +30,7 @@ our %Wordlist; ## no critic ( Variables::ProhibitPackageVars )
 
 sub _copy_wordlist { return { %Wordlist } }
 
-foreach ( dist_file('Pod-Spell', 'wordlist')->lines_utf8({ chomp => 1 })) {
+foreach ( path(_DIST_DIR,'wordlist')->lines_utf8({ chomp => 1 })) {
 	$Wordlist{$_} = 1;
 	$Wordlist{PL($_)} = 1;
 }


### PR DESCRIPTION
This should be notably more stable, predictable, and less likely to pull garbage into the river
like File::ShareDir::ProjectDistDir and File::Share do, while still retaining desired properties.

1. Logic happens at compile time, so no chance of `__FILE__`
no longer being in the right place due to somebody chdiring() underneath
us.

2. Because of #1, no need for heuristics.
3. Pod::Wordlists location is known to this code, so no need for
heuristic guessing trying to compute where the share dir "Should" be.
4. No spooky distant magic with wrapping File::ShareDir functions with
Path::Class in the wrong place.
5. Resolved Path is constant folded, making debugging the resolved path
as simple as:

   perl -MO=Deparse lib/Pod/Wordlist.pm

6. No spooky magic with `@INC` walking

The logic is quite straight forward:

1. Work out what `__FILE__` name is from caller ( prior to `__FILE__`
    existing )
2. If file exists ( ergo, its not a fatpacked file or an eval/do thing )
  then see if there's the known, relative, share location.
3. If the relative share location exists, use that.
4. Otherwise, fallback to File::ShareDir

NOTE
-----

This change should invoke extensive testing because it touches platform sensitive things like path handling. 

Closes #20 ( By superseding it )
Closes #19 