### PR TITLE
[PRC] Fix #21 : stop words with dots not correctly checked

### DIFF
--- a/lib/Pod/Wordlist.pm
+++ b/lib/Pod/Wordlist.pm
@@ -139,15 +139,15 @@ sub _strip_a_word {
 	my ($self, $word) = @_;
 	my $remainder;
 
+	# try word as-is, including possible hyphenation vs stoplist
+	if ($self->is_stopword($word) ) {
+		$remainder = '';
+	}
 	# internal period could be abbreviations, so check with
 	# trailing period restored and drop or keep on that basis
-	if ( /\./ ) {
+	elsif ( $word =~ /\./ ) {
 		my $abbr = "$word.";
 		$remainder = $self->is_stopword($abbr) ? '' : $abbr;
-	}
-	# try word as-is, including possible hyphenation vs stoplist
-	elsif ($self->is_stopword($word) ) {
-		$remainder = '';
 	}
 	# check individual parts of hyphenated word, keep whatever isn't a
 	# stopword as individual words

--- a/t/fix_21.t
+++ b/t/fix_21.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Pod::Spell;
+use Pod::Wordlist;
+
+my $DEBUG = 0;
+my $w;
+
+$w = Pod::Wordlist->new(_is_debug => $DEBUG); 
+$w->learn_stopwords("Ph.D"); 
+is $w->strip_stopwords("Ph.D. John Doe"), "John Doe", "Abbreviation without final dot";
+
+$w = Pod::Wordlist->new(_is_debug => $DEBUG); 
+$w->learn_stopwords("Ph.D."); 
+is $w->strip_stopwords("Ph.D. John Doe"), "John Doe", "Abbreviation with final dot";
+
+$w = Pod::Wordlist->new(_is_debug => $DEBUG); 
+$w->learn_stopwords("anaglyph.pl"); 
+is $w->strip_stopwords("Name: anaglyph.pl"), "Name", "Program name with extension";
+
+done_testing;

--- a/t/fix_21.t
+++ b/t/fix_21.t
@@ -21,3 +21,4 @@ $w->learn_stopwords("anaglyph.pl");
 is $w->strip_stopwords("Name: anaglyph.pl"), "Name", "Program name with extension";
 
 done_testing;
+

--- a/t/fix_21.t
+++ b/t/fix_21.t
@@ -21,4 +21,3 @@ $w->learn_stopwords("anaglyph.pl");
 is $w->strip_stopwords("Name: anaglyph.pl"), "Name", "Program name with extension";
 
 done_testing;
-

--- a/t/fix_21.t
+++ b/t/fix_21.t
@@ -8,16 +8,16 @@ use Pod::Wordlist;
 my $DEBUG = 0;
 my $w;
 
-$w = Pod::Wordlist->new(_is_debug => $DEBUG); 
+$w = Pod::Wordlist->new(_is_debug => $DEBUG);
 $w->learn_stopwords("Ph.D"); 
 is $w->strip_stopwords("Ph.D. John Doe"), "John Doe", "Abbreviation without final dot";
 
-$w = Pod::Wordlist->new(_is_debug => $DEBUG); 
+$w = Pod::Wordlist->new(_is_debug => $DEBUG);
 $w->learn_stopwords("Ph.D."); 
 is $w->strip_stopwords("Ph.D. John Doe"), "John Doe", "Abbreviation with final dot";
 
-$w = Pod::Wordlist->new(_is_debug => $DEBUG); 
-$w->learn_stopwords("anaglyph.pl"); 
+$w = Pod::Wordlist->new(_is_debug => $DEBUG);
+$w->learn_stopwords("anaglyph.pl");
 is $w->strip_stopwords("Name: anaglyph.pl"), "Name", "Program name with extension";
 
 done_testing;

--- a/t/fix_21.t
+++ b/t/fix_21.t
@@ -9,11 +9,11 @@ my $DEBUG = 0;
 my $w;
 
 $w = Pod::Wordlist->new(_is_debug => $DEBUG);
-$w->learn_stopwords("Ph.D"); 
+$w->learn_stopwords("Ph.D");
 is $w->strip_stopwords("Ph.D. John Doe"), "John Doe", "Abbreviation without final dot";
 
 $w = Pod::Wordlist->new(_is_debug => $DEBUG);
-$w->learn_stopwords("Ph.D."); 
+$w->learn_stopwords("Ph.D.");
 is $w->strip_stopwords("Ph.D. John Doe"), "John Doe", "Abbreviation with final dot";
 
 $w = Pod::Wordlist->new(_is_debug => $DEBUG);


### PR DESCRIPTION
Check for word abbreviations was not correct.
Add text t/fix_21.t to assert correction.