### PR TITLE
fix handling of spaces in C<> and F<> tags

### DIFF
--- a/lib/Pod/Spell.pm
+++ b/lib/Pod/Spell.pm
@@ -209,9 +209,9 @@ sub interior_sequence { ## no critic ( Subroutines::RequireFinalReturn )
 
 		# don't lose word-boundaries
 		my $out = '';
-		$out .= ' ' if s/^\s+//s;
+		$out .= ' ' if $seq_arg =~ s/^\s+//s;
 		my $append;
-		$append = 1 if s/\s+$//s;
+		$append = 1 if $seq_arg =~ s/\s+$//s;
 		$out .= '_' if length $seq_arg;
 
 		# which, if joined to another word, will set off the Perl-token alarm

--- a/t/basic.t
+++ b/t/basic.t
@@ -20,6 +20,12 @@ print $podfile "\n=head1 TEST tree's undef\n"
 	. "\nPleumgh bruble-gruble DDGGSS's zpaph's zpaph-kafdkaj-snee myormsp snickh furbles.\n"
 	. "\nFoo::Bar \$a \@b \%c __PACKAGE__->mumble() Foo->{\$bar}\n"
 	. qq[\n"'" Kh.D. ('WinX32'.) L<Storable>'s\n]
+	. qq[\nbeforecode C<incode> aftercode\n]
+	. qq[\nbeforespacecodeC< inspacecode >afterspacecode\n]
+	. qq[\nbeforejoinedcodeC<injoinedcode>afterjoinedcode\n]
+	. qq[\nbeforeprecodeC<inprecode >afterprecode\n]
+	. qq[\nbeforepostcodeC< inpostcode>afterpostcode\n]
+	. qq[\nbeforeescapecodeC<E<gt> inescapecode>afterescapecode\n]
 	. qq[\n]
 	;
 
@@ -37,7 +43,13 @@ my $in = do { local $/ = undef, <$textfile> };
 
 my @words = split " ", $in;
 
-my @expected = qw( TEST tree kafdkaj snee myormsp snickh Kh.D. WinX32 s );
+my @expected = qw(
+    TEST tree kafdkaj snee myormsp snickh Kh.D. WinX32 s
+    beforecode aftercode
+    beforespacecode afterspacecode
+    afterprecode
+    beforepostcode
+);
 is scalar @words, scalar @expected, 'word count';
 
 cmp_deeply \@words, bag( @expected ), 'words match'


### PR DESCRIPTION
The C<> and F<> tags are meant to be removed from the final output, but
if they are directly next to other text, are meant to add an underscore
to that text, causing them to be parsed as a perl token and ignored.

The regexes for spaces were operating on $_, an internal value in
Pod::Parser, rather than $seq_arg, the actual content of the tag. The
value of $_ would be almost, but not exactly the same. It would include
the ending > from the tag, and if there was an internal tag (like E<>)
it would omit that tag and anything before it. Including the end tag
would mean that it would never match the ending whitespace, and skipping
past interior tags would sometimes accidentally find starting whitespace
that shouldn't have matched.

Correct the regexes to operate on the correct variable, and add a test
for the result.